### PR TITLE
Handle errors better

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -10,12 +10,12 @@ async fn main() {
         .queue("images:resize", resize_images);
     queues.listen();
 
-    queues.dispatch("images:resize", json!(["image1.jpg", "image2.jpg"]));
-    queues.dispatch("avatars:resize", json!(["avatar1.jpg", "avatar2.jpg"]));
+    queues.dispatch("images:resize", json!(["image1.jpg", "image2.jpg"])).expect("Failed to dispatch job.");
+    queues.dispatch("avatars:resize", json!(["avatar1.jpg", "avatar2.jpg"])).expect("Failed to dispatch job.");
 
     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
-    queues.shutdown();
+    queues.shutdown().unwrap();
 }
 
 fn resize_avatars(job: Job) -> Result<(), Error> {

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -10,8 +10,12 @@ async fn main() {
         .queue("images:resize", resize_images);
     queues.listen();
 
-    queues.dispatch("images:resize", json!(["image1.jpg", "image2.jpg"])).expect("Failed to dispatch job.");
-    queues.dispatch("avatars:resize", json!(["avatar1.jpg", "avatar2.jpg"])).expect("Failed to dispatch job.");
+    queues
+        .dispatch("images:resize", json!(["image1.jpg", "image2.jpg"]))
+        .expect("Failed to dispatch job.");
+    queues
+        .dispatch("avatars:resize", json!(["avatar1.jpg", "avatar2.jpg"]))
+        .expect("Failed to dispatch job.");
 
     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,4 +7,11 @@ pub enum Error {
 
     #[error(transparent)]
     Redis(#[from] redis::RedisError),
+
+    #[error(transparent)]
+    TokioSend(#[from] tokio::sync::broadcast::error::SendError<()>),
+
+    /// Generic Error to be used Handlers
+    #[error(transparent)]
+    Generic(#[from] Box<dyn std::error::Error + Send + Sync>),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@
 //!     // -- snip --
 //!
 //!    // Shutdown the queues.
-//!     queues.shutdown();
+//!     queues.shutdown().unwrap();
 //! }
 //! ```
 
@@ -79,10 +79,12 @@ impl Redeez {
     }
 
     /// Dispatches a job to the queue with the given name.
-    pub fn dispatch(&self, name: &str, payload: Value) {
+    pub fn dispatch(&self, name: &str, payload: Value) -> Result<()> {
         if let Some(queue) = self.queues.get(name) {
-            queue.dispatch(payload);
+            queue.dispatch(payload)?;
         }
+
+        Ok(())
     }
 
     /// Starts listening for new jobs on all queues.
@@ -98,18 +100,16 @@ impl Redeez {
 
     /// Returns a map of queue names to their stats.
     ///
-    /// # Panics
-    ///
-    /// This function will panic if any of the queues fail to return their stats.
+    /// If any queue fails to return stats the function will error.
     #[must_use]
-    pub fn stats(&self) -> HashMap<&str, Stats> {
+    pub fn stats(&self) -> Result<HashMap<&str, Stats>> {
         let mut stats = HashMap::new();
 
         for (name, queue) in &self.queues {
-            stats.insert(name.as_str(), queue.stats().unwrap());
+            stats.insert(name.as_str(), queue.stats()?);
         }
 
-        stats
+        Ok(stats)
     }
 
     /// Shuts down the Redeez instance and stops listening for new jobs.
@@ -117,7 +117,8 @@ impl Redeez {
     /// # Panics
     ///
     /// This function will panic if the shutdown signal fails to send.
-    pub fn shutdown(&mut self) {
-        self.shutdown_signal.send(()).unwrap();
+    pub fn shutdown(&mut self) -> Result<()> {
+        self.shutdown_signal.send(())?;
+        Ok(())
     }
 }

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -30,7 +30,10 @@ impl Job {
 
 impl Display for Job {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&serde_json::to_string(&self).unwrap_or(format!("Job: id={}, payload=failed to serialize", self.id)))
+        f.write_str(
+            &serde_json::to_string(&self)
+                .unwrap_or(format!("Job: id={}, payload=failed to serialize", self.id)),
+        )
     }
 }
 
@@ -103,8 +106,7 @@ impl Queue {
     pub(crate) fn dispatch(&self, payload: Value) -> Result<()> {
         let mut con = self.client.get_connection()?;
 
-        let res: () = con
-            .lpush(&self.queues.pending, Job::with_data(payload).to_string())?;
+        let res: () = con.lpush(&self.queues.pending, Job::with_data(payload).to_string())?;
 
         Ok(res)
     }


### PR DESCRIPTION
Removes all uses of `unwrap` so the library can no-longer panic, also adds a `Generic` value to the `Error` enum to be used by handlers that wish to return a custom error