### PR TITLE
Replace BRPOPLPUSH for BLMOVE

### DIFF
--- a/src/queue.rs
+++ b/src/queue.rs
@@ -121,8 +121,14 @@ impl Queue {
         let mut con = self.client.get_connection().unwrap();
 
         while shutdown.try_recv().is_err() {
-            let Ok(payload) = con.blmove::<_, _, String>(&self.queues.pending, &self.queues.recovery, Direction::Right, Direction::Left, 5) else {
-                continue
+            let Ok(payload) = con.blmove::<_, _, String>(
+                &self.queues.pending,
+                &self.queues.recovery,
+                Direction::Right,
+                Direction::Left,
+                5,
+            ) else {
+                continue;
             };
 
             match (self.handler)(Job::from_string(&payload)?) {

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -1,5 +1,5 @@
 use crate::error::Result;
-use redis::Commands;
+use redis::{Commands, Direction};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::fmt::{Display, Formatter};
@@ -121,7 +121,7 @@ impl Queue {
         let mut con = self.client.get_connection().unwrap();
 
         while shutdown.try_recv().is_err() {
-            let Ok(payload) = con.brpoplpush::<_, _, String>(&self.queues.pending, &self.queues.recovery, 5) else {
+            let Ok(payload) = con.blmove::<_, _, String>(&self.queues.pending, &self.queues.recovery, Direction::Right, Direction::Left, 5) else {
                 continue
             };
 


### PR DESCRIPTION
This pull request addresses the deprecation of the `BRPOPLPUSH` Redis command by replacing it with the recommended `BLMOVE` command, which was introduced in Redis version 6.2.0.

https://redis.io/docs/latest/commands/brpoplpush/